### PR TITLE
Add page attribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6.3.0
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
       - uses: actions/configure-pages@v6.0.0
       - uses: actions/setup-node@v6.3.0
         with:

--- a/.mailmap
+++ b/.mailmap
@@ -1,10 +1,10 @@
 Adam Grzybowski <adamgrzybowski@users.noreply.github.com>
-Jan Nowakowski <jnowakow@users.noreply.github.com>
-Karol Binkowski <karolbinkowski3@users.noreply.github.com> <karolbinkowski3@proton.me>
+Adrianna Cetnar <lys1k@users.noreply.github.com> <100601969+lys1k@users.noreply.github.com>
 Jakub Kosmydel <kosmydel@users.noreply.github.com>
-Adrianna Cetnar <lys1k@users.noreply.github.com>
+Jan Nowakowski <jnowakow@users.noreply.github.com> <56261019+jnowakow@users.noreply.github.com>
+Karol Binkowski <karolbinkowski3@users.noreply.github.com> <karolbinkowski3@proton.me>
 Marek Kaput <mkaput@users.noreply.github.com> <marek.kaput@swmansion.com>
-Piotr Zborowski <p3t3rzb@users.noreply.github.com>
-Oskar Pawica <pawicao@users.noreply.github.com>
+Oskar Pawica <pawicao@users.noreply.github.com> <34246839+pawicao@users.noreply.github.com>
+Piotr Zborowski <p3t3rzb@users.noreply.github.com> <86735067+p3t3rzb@users.noreply.github.com>
 Sebastian Szewczyk <sebryu@users.noreply.github.com> <sebastian.szewczyk@swmansion.com>
 Sebastian Szewczyk <sebryu@users.noreply.github.com> <sebryu@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,10 @@
+Adam Grzybowski <adamgrzybowski@users.noreply.github.com>
+Jan Nowakowski <jnowakow@users.noreply.github.com>
+Karol Binkowski <karolbinkowski3@users.noreply.github.com> <karolbinkowski3@proton.me>
+Jakub Kosmydel <kosmydel@users.noreply.github.com>
+Adrianna Cetnar <lys1k@users.noreply.github.com>
+Marek Kaput <mkaput@users.noreply.github.com> <marek.kaput@swmansion.com>
+Piotr Zborowski <p3t3rzb@users.noreply.github.com>
+Oskar Pawica <pawicao@users.noreply.github.com>
+Sebastian Szewczyk <sebryu@users.noreply.github.com> <sebastian.szewczyk@swmansion.com>
+Sebastian Szewczyk <sebryu@users.noreply.github.com> <sebryu@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,6 @@
 Adam Grzybowski <adamgrzybowski@users.noreply.github.com>
 Adrianna Cetnar <lys1k@users.noreply.github.com> <100601969+lys1k@users.noreply.github.com>
+github-actions[bot] <github-actions[bot]@users.noreply.github.com> <41898282+github-actions[bot]@users.noreply.github.com>
 Jakub Kosmydel <kosmydel@users.noreply.github.com>
 Jan Nowakowski <jnowakow@users.noreply.github.com> <56261019+jnowakow@users.noreply.github.com>
 Karol Binkowski <karolbinkowski3@users.noreply.github.com> <karolbinkowski3@proton.me>

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@astrojs/starlight": "^0.38.2",
         "@std/csv": "npm:@jsr/std__csv",
         "astro": "^6.1.3",
+        "execa": "^9.6.1",
         "sharp": "^0.34.5",
         "starlight-llms-txt": "^0.8.0",
       },
@@ -263,6 +264,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
 
+    "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
+
     "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
 
     "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag=="],
@@ -278,6 +281,8 @@
     "@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
     "@std/csv": ["@jsr/std__csv@1.0.6", "https://npm.jsr.io/~/11/@jsr/std__csv/1.0.6.tgz", { "dependencies": { "@jsr/std__streams": "^1.0.9" } }, "sha512-9n/SZzjolPQ907gUPksQU3EFURwRl4GA9V6MylA8hpSkpxhcj6J98zDpn9EmDqgE2A4L9MnlUvFhRpeWl+Y/ZQ=="],
 
@@ -405,6 +410,8 @@
 
     "cookie-es": ["cookie-es@1.2.2", "", {}, "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="],
 
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
     "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
@@ -485,6 +492,8 @@
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
+    "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
     "expressive-code": ["expressive-code@0.41.7", "", { "dependencies": { "@expressive-code/core": "^0.41.7", "@expressive-code/plugin-frames": "^0.41.7", "@expressive-code/plugin-shiki": "^0.41.7", "@expressive-code/plugin-text-markers": "^0.41.7" } }, "sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
@@ -494,6 +503,8 @@
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
@@ -506,6 +517,8 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
@@ -561,6 +574,8 @@
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
+    "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
+
     "i18next": ["i18next@23.16.8", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
@@ -585,7 +600,13 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
     "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -739,6 +760,8 @@
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
+    "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
+
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
@@ -765,9 +788,13 @@
 
     "parse-latin": ["parse-latin@7.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "@types/unist": "^3.0.0", "nlcst-to-string": "^4.0.0", "unist-util-modify-children": "^4.0.0", "unist-util-visit-children": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ=="],
 
+    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
+
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
 
@@ -784,6 +811,8 @@
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "prettier-plugin-astro": ["prettier-plugin-astro@0.14.1", "", { "dependencies": { "@astrojs/compiler": "^2.9.1", "prettier": "^3.0.0", "sass-formatter": "^0.7.6" } }, "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw=="],
+
+    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
@@ -865,7 +894,13 @@
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
@@ -888,6 +923,8 @@
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
@@ -930,6 +967,8 @@
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
@@ -1007,6 +1046,8 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -1024,6 +1065,8 @@
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
+
+    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -1048,6 +1091,8 @@
     "estree-util-build-jsx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "scripts": {
     "astro": "astro",
     "build": "astro build",
-    "check": "prettier --check . && astro check && bun links --check",
+    "check": "prettier --check . && astro check && bun links --check && bun mailmap --check",
     "dev": "astro dev",
-    "lint": "prettier --write . && astro check && bun links",
+    "lint": "prettier --write . && astro check && bun links && bun mailmap",
     "links": "bun run scripts/links.ts",
+    "mailmap": "bun run scripts/mailmap.ts",
     "preview": "astro preview",
     "start": "astro dev"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@astrojs/starlight": "^0.38.2",
     "@std/csv": "npm:@jsr/std__csv",
     "astro": "^6.1.3",
+    "execa": "^9.6.1",
     "sharp": "^0.34.5",
     "starlight-llms-txt": "^0.8.0"
   },

--- a/scripts/mailmap.ts
+++ b/scripts/mailmap.ts
@@ -1,0 +1,319 @@
+#!/usr/bin/env bun
+
+import { existsSync } from "node:fs";
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { execa } from "execa";
+import { type MailmapEntry, Mailmap, mailmapPath } from "../src/lib/mailmap";
+
+type CommitAuthor = {
+  file: string;
+  sha: string;
+  name: string;
+  email: string;
+};
+
+type GitHubCommitResponse = {
+  author?: {
+    login?: string;
+  } | null;
+  commit?: {
+    author?: {
+      name?: string;
+    } | null;
+  };
+};
+
+type GitHubUserResponse = {
+  login?: string;
+  name?: string | null;
+};
+
+const CHECK_MODE = process.argv.includes("--check");
+const REPOSITORY = "software-mansion/agentic-engineering";
+const MAILMAP_PATH = path.join(process.cwd(), ".mailmap");
+
+async function main(): Promise<void> {
+  const commitAuthors = await loadCommitAuthors();
+  const mailmap = await loadMailmap();
+
+  if (!CHECK_MODE) {
+    const entries = await updateEntries(mailmap.entries(), commitAuthors);
+    const nextText = Mailmap.fromEntries(entries).toString();
+    const currentText = existsSync(MAILMAP_PATH)
+      ? await readFile(MAILMAP_PATH, "utf8")
+      : "";
+
+    if (normalizeNewlines(currentText) !== nextText) {
+      await writeFile(MAILMAP_PATH, nextText, "utf8");
+      console.log(`Updated ${path.relative(process.cwd(), MAILMAP_PATH)}`);
+    }
+  }
+
+  const validationErrors = await validateMailmap(await loadMailmap(), {
+    commitAuthors,
+  });
+
+  if (validationErrors.length > 0) {
+    console.error("Mailmap validation failed.");
+    for (const error of validationErrors) {
+      console.error(error);
+    }
+    console.error("Run: bun mailmap");
+    process.exit(1);
+  }
+
+  if (CHECK_MODE) {
+    console.log("Mailmap validation passed.");
+  }
+}
+
+async function loadMailmap() {
+  if (!existsSync(MAILMAP_PATH)) {
+    return Mailmap.fromEntries([]);
+  }
+
+  return Mailmap.load(mailmapPath);
+}
+
+async function loadCommitAuthors(): Promise<CommitAuthor[]> {
+  const commitAuthors: CommitAuthor[] = [];
+
+  for (const file of await loadDocFiles()) {
+    const { stdout } = await execa("git", [
+      "log",
+      "--follow",
+      "--format=%H%x09%aN%x09%aE",
+      "--",
+      file,
+    ]);
+
+    for (const line of stdout.split("\n")) {
+      const [sha, name, email] = line.split("\t");
+      if (!sha || !name || !email) {
+        continue;
+      }
+
+      commitAuthors.push({
+        file: path.relative(process.cwd(), file),
+        sha,
+        name,
+        email,
+      });
+    }
+  }
+
+  return commitAuthors;
+}
+
+async function loadDocFiles(): Promise<string[]> {
+  const docsRoot = path.join(process.cwd(), "src", "content", "docs");
+  const files = await collectDocsRecursive(docsRoot);
+  files.sort((a, b) => a.localeCompare(b));
+  return files;
+}
+
+async function collectDocsRecursive(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectDocsRecursive(fullPath)));
+      continue;
+    }
+
+    if (
+      entry.isFile() &&
+      (fullPath.endsWith(".md") || fullPath.endsWith(".mdx"))
+    ) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+async function updateEntries(
+  currentEntries: MailmapEntry[],
+  commitAuthors: CommitAuthor[],
+) {
+  const entriesByGithub = new Map<string, MailmapEntry>();
+
+  for (const entry of currentEntries) {
+    const existingEntry = entriesByGithub.get(entry.github);
+    if (existingEntry) {
+      existingEntry.emails.push(...entry.emails);
+      continue;
+    }
+
+    entriesByGithub.set(entry.github, { ...entry, emails: [...entry.emails] });
+  }
+
+  for (const person of commitAuthors) {
+    const existingGithub = getExistingGithubForEmail(
+      entriesByGithub,
+      person.email,
+    );
+    const commitAuthor = existingGithub
+      ? null
+      : await fetchGitHubCommitAuthor(person.sha);
+    const resolvedGithub = existingGithub ?? commitAuthor?.github;
+
+    if (!resolvedGithub) {
+      throw new Error(
+        `No GitHub user found for ${person.file} commit ${person.sha.slice(0, 7)} by ${person.name} <${person.email}>. Add a .mailmap entry like: Name <github@users.noreply.github.com> <${person.email}>.`,
+      );
+    }
+
+    await ensureGitHubProfile(
+      entriesByGithub,
+      resolvedGithub,
+      commitAuthor?.name ?? person.name,
+    );
+    entriesByGithub.get(resolvedGithub)?.emails.push(person.email);
+  }
+
+  return Array.from(entriesByGithub.values());
+}
+
+async function ensureGitHubProfile(
+  entriesByGithub: Map<string, MailmapEntry>,
+  github: string,
+  fallbackName = github,
+) {
+  const normalizedGithub = github.toLowerCase();
+
+  if (entriesByGithub.has(normalizedGithub)) {
+    return;
+  }
+
+  const user = await fetchGitHubUser(normalizedGithub);
+
+  entriesByGithub.set(normalizedGithub, {
+    github: normalizedGithub,
+    name: user.name || fallbackName,
+    emails: [`${normalizedGithub}@users.noreply.github.com`],
+  });
+}
+
+function getExistingGithubForEmail(
+  entriesByGithub: Map<string, MailmapEntry>,
+  email: string,
+) {
+  const normalizedEmail = email.toLowerCase();
+
+  for (const [github, entry] of entriesByGithub) {
+    if (
+      entry.emails
+        .map((entryEmail) => entryEmail.toLowerCase())
+        .includes(normalizedEmail)
+    ) {
+      return github;
+    }
+  }
+
+  return undefined;
+}
+
+async function fetchGitHubCommitAuthor(sha: string) {
+  const response = await fetchGitHub<GitHubCommitResponse>(
+    `https://api.github.com/repos/${REPOSITORY}/commits/${sha}`,
+  );
+  const github = response.author?.login?.toLowerCase();
+
+  if (!github) {
+    return null;
+  }
+
+  return {
+    github,
+    name: response.commit?.author?.name ?? github,
+  };
+}
+
+async function fetchGitHubUser(github: string) {
+  const response = await fetchGitHub<GitHubUserResponse>(
+    `https://api.github.com/users/${github}`,
+  );
+
+  if (!response.login) {
+    throw new Error(`GitHub API did not return a login for "${github}".`);
+  }
+
+  return {
+    github: response.login.toLowerCase(),
+    name: response.name?.trim() || response.login,
+  };
+}
+
+async function fetchGitHub<T>(url: string): Promise<T> {
+  const headers = new Headers({
+    accept: "application/vnd.github+json",
+    "user-agent": "software-mansion-mailmap-bot/1.0",
+    "x-github-api-version": "2022-11-28",
+  });
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+
+  if (token) {
+    headers.set("authorization", `Bearer ${token}`);
+  }
+
+  const response = await fetch(url, { headers });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API request failed (${response.status} ${response.statusText}): ${url}`,
+    );
+  }
+
+  return response.json() as Promise<T>;
+}
+
+async function validateMailmap(
+  mailmap: Mailmap,
+  {
+    commitAuthors,
+  }: {
+    commitAuthors: CommitAuthor[];
+  },
+) {
+  const validationErrors: string[] = [];
+
+  for (const commitAuthor of commitAuthors) {
+    try {
+      const github = mailmap.getGithubForEmail(commitAuthor.email);
+      mailmap.getProfile(github);
+    } catch (error) {
+      validationErrors.push(
+        `${commitAuthor.file}: commit ${commitAuthor.sha.slice(0, 7)} by ${commitAuthor.name} <${commitAuthor.email}>: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  const currentText = existsSync(MAILMAP_PATH)
+    ? Bun.file(MAILMAP_PATH).text()
+    : Promise.resolve("");
+
+  validationErrors.push(...(await validateSortedMailmap(mailmap, currentText)));
+
+  return validationErrors;
+}
+
+async function validateSortedMailmap(
+  mailmap: Mailmap,
+  currentText: Promise<string>,
+) {
+  if (normalizeNewlines(await currentText) === mailmap.toString()) {
+    return [];
+  }
+
+  return [".mailmap is not normalized/sorted. Run: bun mailmap"];
+}
+
+function normalizeNewlines(value: string): string {
+  return value.replace(/\r\n/g, "\n");
+}
+
+await main();

--- a/src/components/Attribution.astro
+++ b/src/components/Attribution.astro
@@ -1,12 +1,13 @@
 ---
 import { getAuthors, getContributors } from "../lib/githubAttribution";
 
-const authors = await getAuthors(Astro);
-const contributors = await getContributors(Astro);
+const { showAttribution } = Astro.locals.starlightRoute.entry.data;
+const authors = showAttribution ? await getAuthors(Astro) : [];
+const contributors = showAttribution ? await getContributors(Astro) : [];
 ---
 
 {
-  Astro.locals.starlightRoute.entry.data.showAttribution && (
+  showAttribution && (
     <section class="attribution" aria-labelledby="page-attribution-title">
       <h2 id="page-attribution-title">Attribution</h2>
       <div class="attribution-groups">

--- a/src/components/Attribution.astro
+++ b/src/components/Attribution.astro
@@ -1,0 +1,143 @@
+---
+import { getAuthors, getContributors } from "../lib/githubAttribution";
+
+const authors = await getAuthors(Astro);
+const contributors = await getContributors(Astro);
+---
+
+{
+  Astro.locals.starlightRoute.entry.data.showAttribution && (
+    <section class="attribution" aria-labelledby="page-attribution-title">
+      <h2 id="page-attribution-title">Attribution</h2>
+      <div class="attribution-groups">
+        <section class="attribution-group" aria-labelledby="page-authors-title">
+          <h3 id="page-authors-title">Authors</h3>
+          <ul class="people-list">
+            {authors.map((person) => (
+              <li>
+                <a
+                  href={person.url}
+                  title={person.name}
+                  aria-label={person.name}
+                >
+                  <img
+                    src={person.avatarUrl}
+                    alt=""
+                    loading="lazy"
+                    decoding="async"
+                    width="96"
+                    height="96"
+                    class="avatar"
+                  />
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+        {contributors.length > 0 && (
+          <section
+            class="attribution-group"
+            aria-labelledby="page-contributors-title"
+          >
+            <h3 id="page-contributors-title">Contributors</h3>
+            <ul class="people-list">
+              {contributors.map((person) => (
+                <li>
+                  <a
+                    href={person.url}
+                    title={person.name}
+                    aria-label={person.name}
+                  >
+                    <img
+                      src={person.avatarUrl}
+                      alt=""
+                      loading="lazy"
+                      decoding="async"
+                      width="96"
+                      height="96"
+                      class="avatar"
+                    />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </div>
+    </section>
+  )
+}
+
+<style>
+  @layer starlight.core {
+    .attribution {
+      margin-top: 3rem;
+      padding-block-start: 1.5rem;
+      border-top: 1px solid var(--sl-color-hairline);
+    }
+
+    .attribution h2 {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    .attribution-groups {
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    @media (min-width: 40rem) {
+      .attribution-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        align-items: start;
+      }
+    }
+
+    .attribution-group h3 {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin: 0 0 0.75rem;
+      color: var(--sl-color-white);
+      font-size: var(--sl-text-lg);
+      line-height: var(--sl-line-height-headings);
+    }
+
+    .people-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .people-list a {
+      display: block;
+      border-radius: 99rem;
+      color: inherit;
+    }
+
+    .people-list a:focus-visible {
+      outline: 2px solid var(--sl-color-accent-high);
+      outline-offset: 3px;
+    }
+
+    .avatar {
+      display: block;
+      width: 3.5rem;
+      height: 3.5rem;
+      border-radius: 99rem;
+      outline: 1px solid rgba(255, 255, 255, 0.33);
+      outline-offset: -1px;
+      background: var(--sl-color-gray-6);
+    }
+  }
+</style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,8 +1,10 @@
 ---
 import Default from "@astrojs/starlight/components/Footer.astro";
+import Attribution from "./Attribution.astro";
 import { swmUrl, feedbackUrl } from "../lib/siteLinks";
 ---
 
+<Attribution />
 <Default><slot /></Default>
 
 <footer class="swm-footer" aria-label="Software Mansion legal notice">

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,9 +1,19 @@
 ---
 import Default from "@astrojs/starlight/components/Head.astro";
 import JsonLD from "./JsonLD.astro";
+import { getAuthors } from "../lib/githubAttribution";
+
+const authors = await getAuthors(Astro);
 ---
 
 <Default />
+
+{authors.map((author) => <meta name="author" content={author.name} />)}
+{
+  authors.map((author) => (
+    <meta property="article:author" content={author.url} />
+  ))
+}
 
 <!-- Google Tag Manager -->
 <script is:inline>

--- a/src/components/JsonLD.astro
+++ b/src/components/JsonLD.astro
@@ -1,4 +1,6 @@
 ---
+import { getAuthors } from "../lib/githubAttribution";
+
 const {
   lang,
   siteTitle,
@@ -12,6 +14,7 @@ const organizationId = "https://swmansion.com/#organization";
 const websiteId = new URL("#website", Astro.site);
 const bookId = new URL("#book", Astro.site);
 const defaultOgImage = new URL("og-default.png?v0", Astro.site);
+const authors = await getAuthors(Astro);
 
 const jsonLdPlaceholders = {
   $site: `${Astro.site}`,
@@ -53,6 +56,12 @@ const basePageNode = isNotFoundPage
       mainEntityOfPage: Astro.url,
       isPartOf: { "@id": bookId },
       publisher: { "@id": organizationId },
+      author: authors.map((author) => ({
+        "@type": "Person",
+        name: author.name,
+        url: author.url,
+        image: author.avatarUrl,
+      })),
       ...(lastUpdated && { dateModified: lastUpdated.toISOString() }),
     };
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,16 +10,33 @@ const jsonLdNodeSchema = z.looseObject({
   "@type": z.string().min(1),
 });
 
+const attributionSchema = z
+  .object({
+    authors: z.array(z.string().min(1)).optional(),
+    showAttribution: z.boolean().default(true),
+  })
+  .superRefine((value, ctx) => {
+    if (value.showAttribution && !value.authors?.length) {
+      ctx.addIssue({
+        code: "custom",
+        message: "authors is required when showAttribution is true.",
+        path: ["authors"],
+      });
+    }
+  });
+
 export const collections = {
   docs: defineCollection({
     loader: docsLoader(),
     schema: docsSchema({
-      extend: z.object({
-        /** All pages all require to have a meaningful description. */
-        description: z.string().min(1),
-        jsonLd: z.array(jsonLdNodeSchema).optional(),
-        clapButtons: z.boolean().default(true),
-      }),
+      extend: z
+        .object({
+          /** All pages are required to have a meaningful description. */
+          description: z.string().min(1),
+          jsonLd: z.array(jsonLdNodeSchema).optional(),
+          clapButtons: z.boolean().default(true),
+        })
+        .and(attributionSchema),
     }),
   }),
   links: defineCollection({

--- a/src/content/docs/becoming-productive/closing-the-loop.mdx
+++ b/src/content/docs/becoming-productive/closing-the-loop.mdx
@@ -1,6 +1,7 @@
 ---
 title: Closing the loop
 description: How to make agents self-correct faster with autonomous feedback loops across tests, logs, CLIs, and manual QA automation.
+authors: [mkaput]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/becoming-productive/going-10x.mdx
+++ b/src/content/docs/becoming-productive/going-10x.mdx
@@ -1,6 +1,7 @@
 ---
 title: Going 10x
 description: Tactics for running multiple coding agents in parallel while managing conflicts, quality, and long-term maintainability.
+authors: [mkaput]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/becoming-productive/harness-engineering.mdx
+++ b/src/content/docs/becoming-productive/harness-engineering.mdx
@@ -4,6 +4,7 @@ description: >-
   Shape the harness around the model with `AGENTS.md`, skills, MCP,
   subagents, and hooks so good agent behavior becomes easier and more
   repeatable.
+authors: [mkaput]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/becoming-productive/legal-compliance.mdx
+++ b/src/content/docs/becoming-productive/legal-compliance.mdx
@@ -3,6 +3,7 @@ title: Legal & Compliance
 description: >-
   Legal and compliance risks of using coding agents with proprietary code,
   including data handling, licensing, contracts, and accountability.
+authors: [mkaput]
 ---
 
 While technical sandboxes prevent agents from wiping databases, they do not

--- a/src/content/docs/becoming-productive/prompting-techniques.mdx
+++ b/src/content/docs/becoming-productive/prompting-techniques.mdx
@@ -1,6 +1,7 @@
 ---
 title: Prompting Techniques
 description: Practical prompting patterns for coding agents, from framing and execution guidance to multimodal input and walkthroughs.
+authors: [mkaput]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/becoming-productive/security.mdx
+++ b/src/content/docs/becoming-productive/security.mdx
@@ -1,6 +1,7 @@
 ---
 title: Security
 description: High-level security model for coding agents, from the Lethal Trifecta to harness defenses and real-world prompt injection failures.
+authors: [mkaput]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/becoming-productive/the-workflow.mdx
+++ b/src/content/docs/becoming-productive/the-workflow.mdx
@@ -1,6 +1,7 @@
 ---
 title: The Workflow
 description: "A baseline workflow for non-trivial agent tasks: brainstorm, plan, execute, review, and improve."
+authors: [mkaput]
 ---
 
 import { Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/becoming-productive/what-not-to-do.mdx
+++ b/src/content/docs/becoming-productive/what-not-to-do.mdx
@@ -1,6 +1,7 @@
 ---
 title: What Not to Do
 description: Common anti-patterns when working with coding agents and how to avoid them.
+authors: [p3t3rzb]
 ---
 
 import { Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/changelog.mdx
+++ b/src/content/docs/changelog.mdx
@@ -4,6 +4,7 @@ description: Daily log of updates and new content added to the guide.
 sidebar:
   hidden: true
 clapButtons: false
+showAttribution: false
 ---
 
 This page is updated automatically each night when new content is added to the guide.

--- a/src/content/docs/expanding-horizons/autoresearch.mdx
+++ b/src/content/docs/expanding-horizons/autoresearch.mdx
@@ -1,6 +1,7 @@
 ---
 title: Autoresearch
 description: A pattern where a coding agent runs semi-autonomous experiments to discover performance improvements or other optimizations.
+authors: [karolbinkowski3]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/expanding-horizons/high-level-harnesses.mdx
+++ b/src/content/docs/expanding-horizons/high-level-harnesses.mdx
@@ -1,6 +1,7 @@
 ---
 title: High-level harnesses
 description: Beyond individual agent sessions — scheduled automations, parallel agent fleets, and the emerging pattern of AI-driven code pipelines.
+authors: [p3t3rzb]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/expanding-horizons/model-evaluation.mdx
+++ b/src/content/docs/expanding-horizons/model-evaluation.mdx
@@ -1,6 +1,7 @@
 ---
 title: Evaluation
 description: Learn how to evaluate LLM performance for agentic workflows using benchmarks, custom evals, and real-world testing.
+authors: [jnowakow]
 ---
 import ExternalLink from "../../../components/ExternalLink.astro";
 

--- a/src/content/docs/expanding-horizons/model-pricing.mdx
+++ b/src/content/docs/expanding-horizons/model-pricing.mdx
@@ -1,6 +1,7 @@
 ---
 title: Model pricing
 description: "A concise guide to coding model pricing, including API costs, caching, and subscription tradeoffs."
+authors: [mkaput, karolbinkowski3]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/expanding-horizons/threads-context-and-caching.mdx
+++ b/src/content/docs/expanding-horizons/threads-context-and-caching.mdx
@@ -1,6 +1,7 @@
 ---
 title: Threads, context, and caching
 description: Understand how thread length, context windows, prompt caching, and compaction shape agent reliability, speed, and cost.
+authors: [mkaput]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/expanding-horizons/what-to-read-next.mdx
+++ b/src/content/docs/expanding-horizons/what-to-read-next.mdx
@@ -1,6 +1,7 @@
 ---
 title: What to read next
 description: Curated blogs and social feeds to follow for ongoing signal on agentic engineering, tooling, and model updates.
+authors: [mkaput, sebryu]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/getting-started/first-steps-in-mature-projects.mdx
+++ b/src/content/docs/getting-started/first-steps-in-mature-projects.mdx
@@ -1,6 +1,7 @@
 ---
 title: First steps in mature projects
 description: A practical onboarding flow for using coding agents in mature codebases with predictable, low-risk, test-first delivery.
+authors: [mkaput]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/getting-started/glossary.mdx
+++ b/src/content/docs/getting-started/glossary.mdx
@@ -1,6 +1,7 @@
 ---
 title: Glossary
 description: Definitions of core terms used throughout this guide.
+authors: [mkaput]
 jsonLd:
   - "@type": "DefinedTermSet"
     "@id": "$pageUrl#defined-term-set"

--- a/src/content/docs/getting-started/how-to-get-started.mdx
+++ b/src/content/docs/getting-started/how-to-get-started.mdx
@@ -3,6 +3,7 @@ title: How to get started?
 description: >-
   A short orientation for this chapter, why hands-on practice matters, and which
   learning path to take first.
+authors: [mkaput, adamgrzybowski, kosmydel]
 ---
 
 This "Getting Started" chapter gives you a concrete sense of what is possible with agentic engineering.

--- a/src/content/docs/getting-started/how-to-set-up-a-new-repo.mdx
+++ b/src/content/docs/getting-started/how-to-set-up-a-new-repo.mdx
@@ -1,6 +1,7 @@
 ---
 title: How to set up a new repo?
 description: Step-by-step setup for starting a new repository with coding agents, from discovery and planning to review and first commit.
+authors: [mkaput, adamgrzybowski, kosmydel]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/getting-started/towards-self-improvement.mdx
+++ b/src/content/docs/getting-started/towards-self-improvement.mdx
@@ -1,6 +1,7 @@
 ---
 title: Towards self-improvement
 description: Start adapting your repository to coding agents with a minimal `AGENTS.md` and a few simple setup conventions.
+authors: [mkaput]
 ---
 
 import ExternalLink from "../../../components/ExternalLink.astro";

--- a/src/content/docs/getting-started/what-can-ai-agents-even-do.mdx
+++ b/src/content/docs/getting-started/what-can-ai-agents-even-do.mdx
@@ -1,6 +1,7 @@
 ---
 title: What can AI agents even do?
 description: A quick capability checklist of what modern coding agents can do across code navigation, debugging, planning, and automation.
+authors: [kosmydel]
 ---
 
 - Index, understand, and navigate your codebase by themselves.

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Welcome to the Software Mansion Agentic Engineering Guide!
 description: Practical guidance for setting up and scaling agentic engineering workflows in real software projects.
+showAttribution: false
 ---
 
 import ExternalLink from "../../components/ExternalLink.astro";

--- a/src/lib/githubAttribution.ts
+++ b/src/lib/githubAttribution.ts
@@ -1,0 +1,77 @@
+import { execa } from "execa";
+import type { AstroGlobal } from "astro";
+import { Mailmap } from "./mailmap";
+
+export type GitHubProfile = {
+  github: string;
+  name: string;
+  avatarUrl: string;
+  url: string;
+};
+
+type AttributionAstro = Pick<AstroGlobal, "locals">;
+
+const mailmapPromise = Mailmap.load();
+
+const getProfile = (github: string, mailmap: Mailmap): GitHubProfile => {
+  const normalizedGithub = github.toLowerCase();
+  const profile = mailmap.getProfile(normalizedGithub);
+
+  return {
+    ...profile,
+    avatarUrl: `https://github.com/${profile.github}.png`,
+    url: `https://github.com/${profile.github}`,
+  };
+};
+
+export const getAuthors = async (astro: AttributionAstro) => {
+  const {
+    entry: { data },
+  } = astro.locals.starlightRoute;
+  const mailmap = await mailmapPromise;
+
+  return (data.authors ?? []).map((github) => getProfile(github, mailmap));
+};
+
+export const getContributors = async (astro: AttributionAstro) => {
+  const {
+    entry: { data, filePath },
+  } = astro.locals.starlightRoute;
+  const mailmap = await mailmapPromise;
+  const authorGithubs = data.authors ?? [];
+  const authorSet = new Set(
+    authorGithubs.map((github) => github.toLowerCase()),
+  );
+  const contributorCounts = new Map<string, number>();
+
+  const { stdout: gitLog } = await execa("git", [
+    "log",
+    "--follow",
+    "--format=%ae",
+    "--",
+    filePath,
+  ]);
+
+  for (const email of gitLog.split("\n")) {
+    const trimmedEmail = email.trim();
+
+    if (!trimmedEmail) {
+      continue;
+    }
+
+    const github = mailmap.getGithubForEmail(trimmedEmail);
+
+    if (authorSet.has(github)) {
+      continue;
+    }
+
+    contributorCounts.set(github, (contributorCounts.get(github) ?? 0) + 1);
+  }
+
+  return Array.from(contributorCounts.entries())
+    .sort(
+      ([firstGithub, firstCount], [secondGithub, secondCount]) =>
+        secondCount - firstCount || firstGithub.localeCompare(secondGithub),
+    )
+    .map(([github]) => getProfile(github, mailmap));
+};

--- a/src/lib/mailmap.ts
+++ b/src/lib/mailmap.ts
@@ -5,16 +5,16 @@ export type MailmapProfile = {
   name: string;
 };
 
-const mailmapPath = new URL("../../.mailmap", import.meta.url);
+export type MailmapEntry = MailmapProfile & {
+  emails: string[];
+};
 
-const getGithubFromEmail = (email: string) =>
+export const mailmapPath = new URL("../../.mailmap", import.meta.url);
+
+export const getGithubFromEmail = (email: string) =>
   email
     .toLowerCase()
     .match(/^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/)?.[1];
-
-type MailmapEntry = MailmapProfile & {
-  emails: string[];
-};
 
 const getMailmapLineError = (lineNumber: number, message: string) =>
   new Error(`Invalid .mailmap entry on line ${lineNumber}: ${message}`);
@@ -69,28 +69,81 @@ const parseMailmap = (mailmap: string) =>
     return profile ? [profile] : [];
   });
 
+const normalizeEmail = (email: string) => email.toLowerCase();
+
+const normalizeEntry = (entry: MailmapEntry): MailmapEntry => ({
+  github: entry.github.toLowerCase(),
+  name: entry.name.trim(),
+  emails: Array.from(new Set(entry.emails.map(normalizeEmail))).sort((a, b) =>
+    a.localeCompare(b),
+  ),
+});
+
+export const serializeMailmapEntries = (entries: MailmapEntry[]) => {
+  const normalizedEntries = entries
+    .map(normalizeEntry)
+    .sort(
+      (first, second) =>
+        first.name.localeCompare(second.name) ||
+        first.github.localeCompare(second.github) ||
+        first.emails.join("\0").localeCompare(second.emails.join("\0")),
+    );
+
+  return `${normalizedEntries
+    .flatMap(({ github, name, emails }) => {
+      const canonicalEmail = `${github}@users.noreply.github.com`;
+      const aliasEmails = emails.filter((email) => email !== canonicalEmail);
+
+      if (aliasEmails.length === 0) {
+        return [`${name} <${canonicalEmail}>`];
+      }
+
+      return aliasEmails.map(
+        (email) => `${name} <${canonicalEmail}> <${email}>`,
+      );
+    })
+    .join("\n")}\n`;
+};
+
 export class Mailmap {
-  static async load() {
-    const entries = parseMailmap(await readFile(mailmapPath, "utf8"));
+  static async load(path: URL | string = mailmapPath) {
+    const entries = parseMailmap(await readFile(path, "utf8"));
     return new Mailmap(entries);
   }
 
+  static fromEntries(entries: MailmapEntry[]) {
+    return new Mailmap(entries);
+  }
+
+  readonly #entries: MailmapEntry[];
   readonly #emailGithubMap: Record<string, string>;
   readonly #profileMap: Record<string, MailmapProfile>;
 
   private constructor(entries: MailmapEntry[]) {
+    this.#entries = entries.map(normalizeEntry);
     this.#emailGithubMap = Object.fromEntries(
-      entries.flatMap(({ emails, github }) =>
+      this.#entries.flatMap(({ emails, github }) =>
         emails.map((email) => [email, github]),
       ),
     );
     this.#profileMap = Object.fromEntries(
-      entries.map(({ github, name }) => [github, { github, name }]),
+      this.#entries.map(({ github, name }) => [github, { github, name }]),
     );
   }
 
+  entries() {
+    return this.#entries.map(({ emails, ...profile }) => ({
+      ...profile,
+      emails: [...emails],
+    }));
+  }
+
+  toString() {
+    return serializeMailmapEntries(this.#entries);
+  }
+
   getGithubForEmail(email: string) {
-    const normalizedEmail = email.toLowerCase();
+    const normalizedEmail = normalizeEmail(email);
 
     // Keep unmapped GitHub noreply commit authors attributable by username.
     const github =

--- a/src/lib/mailmap.ts
+++ b/src/lib/mailmap.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import path from "node:path";
 
 export type MailmapProfile = {
   github: string;
@@ -9,7 +10,7 @@ export type MailmapEntry = MailmapProfile & {
   emails: string[];
 };
 
-export const mailmapPath = new URL("../../.mailmap", import.meta.url);
+export const mailmapPath = path.join(process.cwd(), ".mailmap");
 
 export const getGithubFromEmail = (email: string) =>
   email

--- a/src/lib/mailmap.ts
+++ b/src/lib/mailmap.ts
@@ -1,0 +1,120 @@
+import { readFile } from "node:fs/promises";
+
+export type MailmapProfile = {
+  github: string;
+  name: string;
+};
+
+const mailmapPath = new URL("../../.mailmap", import.meta.url);
+
+const getGithubFromEmail = (email: string) =>
+  email
+    .toLowerCase()
+    .match(/^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/)?.[1];
+
+type MailmapEntry = MailmapProfile & {
+  emails: string[];
+};
+
+const getMailmapLineError = (lineNumber: number, message: string) =>
+  new Error(`Invalid .mailmap entry on line ${lineNumber}: ${message}`);
+
+const parseMailmapLine = (
+  line: string,
+  lineNumber: number,
+): MailmapEntry | null => {
+  const trimmedLine = line.trim();
+
+  if (!trimmedLine || trimmedLine.startsWith("#")) {
+    return null;
+  }
+
+  const emails = Array.from(trimmedLine.matchAll(/<([^>]+)>/g), (match) =>
+    match[1].toLowerCase(),
+  );
+  const [canonicalEmail, ...aliasEmails] = emails;
+
+  if (!canonicalEmail) {
+    throw getMailmapLineError(
+      lineNumber,
+      "expected a canonical email address.",
+    );
+  }
+
+  const github = getGithubFromEmail(canonicalEmail);
+
+  if (!github) {
+    throw getMailmapLineError(
+      lineNumber,
+      `canonical email "${canonicalEmail}" must be a GitHub noreply address.`,
+    );
+  }
+
+  const name = trimmedLine.slice(0, trimmedLine.indexOf("<")).trim();
+
+  if (!name) {
+    throw getMailmapLineError(lineNumber, "expected a canonical name.");
+  }
+
+  return {
+    github,
+    name,
+    emails: [canonicalEmail, ...aliasEmails],
+  };
+};
+
+const parseMailmap = (mailmap: string) =>
+  mailmap.split("\n").flatMap((line, index) => {
+    const profile = parseMailmapLine(line, index + 1);
+    return profile ? [profile] : [];
+  });
+
+export class Mailmap {
+  static async load() {
+    const entries = parseMailmap(await readFile(mailmapPath, "utf8"));
+    return new Mailmap(entries);
+  }
+
+  readonly #emailGithubMap: Record<string, string>;
+  readonly #profileMap: Record<string, MailmapProfile>;
+
+  private constructor(entries: MailmapEntry[]) {
+    this.#emailGithubMap = Object.fromEntries(
+      entries.flatMap(({ emails, github }) =>
+        emails.map((email) => [email, github]),
+      ),
+    );
+    this.#profileMap = Object.fromEntries(
+      entries.map(({ github, name }) => [github, { github, name }]),
+    );
+  }
+
+  getGithubForEmail(email: string) {
+    const normalizedEmail = email.toLowerCase();
+
+    // Keep unmapped GitHub noreply commit authors attributable by username.
+    const github =
+      this.#emailGithubMap[normalizedEmail] ??
+      getGithubFromEmail(normalizedEmail);
+
+    if (!github) {
+      throw new Error(
+        `No GitHub username found for email "${email}". Add a .mailmap entry like: Name <github@users.noreply.github.com> <${email}>.`,
+      );
+    }
+
+    return github;
+  }
+
+  getProfile(github: string) {
+    const profile = this.#profileMap[github.toLowerCase()];
+
+    if (!profile) {
+      throw new Error(
+        `No .mailmap profile found for GitHub user "${github}". Add a .mailmap entry like: Name <${github}@users.noreply.github.com>.`,
+      );
+    }
+
+    return profile;
+  }
+}


### PR DESCRIPTION
## Summary
- adds page author and contributor attribution from frontmatter and git history
- uses .mailmap-backed GitHub profiles with a `bun mailmap` lint/update command
- emits author meta tags and JSON-LD author data

<img width="770" height="260" alt="image" src="https://github.com/user-attachments/assets/2f3e290e-f22f-4578-9732-d28be51004c5" />


## Checks
- `bun run check`
- `bun run build`
