### PR TITLE
Update guide revision date to June 2026

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -12,7 +12,7 @@ We are sharing it publicly so more teams can build with these methods.
 :::caution
 Be aware that this document is just a snapshot of the state of the art at the time of the last revision.
 Things change rapidly in this space.
-**Last revised: April 2026**
+**Last revised: June 2026**
 :::
 
 Think of this document as a sidekick you keep open while you work.


### PR DESCRIPTION
## Summary
- Update the homepage caution note to show `Last revised: June 2026`.
- Keep the change scoped to the guide content only.

## Testing
- `bun lint` passed.
- `bun run build` passed.