### PR TITLE
send plaintext changelog messages to Slack

### DIFF
--- a/.github/prompts/changelog.md
+++ b/.github/prompts/changelog.md
@@ -5,6 +5,9 @@ Given a git patch showing changes to the guide's content files (MDX), write a co
 ## Output format
 
 Call the `submit_changelog_entry` tool with your result.
+For non-trivial changes, submit both:
+- `entry`: markdown for `changelog.mdx`.
+- `slackMessage`: plaintext for Slack.
 
 ## Entry style
 
@@ -27,3 +30,18 @@ Rules:
 - Never mention file names, component names, or implementation details.
 - Set `trivial: true` (and omit `entry`) when changes are purely cosmetic with no new knowledge for readers: typo fixes, punctuation, link metadata, formatting.
 - The date in the heading must match the date of the commits in the patch.
+
+## Slack message style
+
+Format `slackMessage` as plaintext only:
+```
+Check out the latest changes to the Agentic Engineering Guide:
+
+Page / Section title — one punchy sentence on what's new or changed.
+Another page — one punchy sentence.
+```
+
+Rules:
+- Do not use Markdown or Slack mrkdwn syntax in `slackMessage`.
+- Use the same changed topics as `entry`.
+- Omit `slackMessage` when `trivial` is true.

--- a/.github/workflows/daily-changelog.yml
+++ b/.github/workflows/daily-changelog.yml
@@ -94,8 +94,8 @@ jobs:
             exit 0
           fi
 
-          if ! jq -e 'type == "object" and .trivial == false and (.entry | type == "string" and test("\\S"))' /tmp/ai-result.json >/dev/null; then
-            echo "Expected a non-trivial changelog entry in /tmp/ai-result.json" >&2
+          if ! jq -e 'type == "object" and .trivial == false and (.entry | type == "string" and test("\\S")) and (.slackMessage | type == "string" and test("\\S"))' /tmp/ai-result.json >/dev/null; then
+            echo "Expected a non-trivial changelog entry and Slack message in /tmp/ai-result.json" >&2
             exit 1
           fi
 

--- a/scripts/changelog/generate-entry.mts
+++ b/scripts/changelog/generate-entry.mts
@@ -47,6 +47,11 @@ const response = await fetch("https://api.anthropic.com/v1/messages", {
               description:
                 "Changelog entry in markdown, starting with ## YYYY-MM-DD heading. Required when trivial is false.",
             },
+            slackMessage: {
+              type: "string",
+              description:
+                "Plaintext Slack message with no Markdown or Slack mrkdwn syntax. Required when trivial is false.",
+            },
           },
           required: ["trivial"],
         },

--- a/scripts/changelog/post-slack.mts
+++ b/scripts/changelog/post-slack.mts
@@ -10,9 +10,9 @@ if (typeof raw !== "object" || raw === null) {
   console.error("[changelog entry] Expected object, got", typeof raw);
   process.exit(1);
 }
-if (typeof raw.entry !== "string" || raw.entry.trim() === "") {
+if (typeof raw.slackMessage !== "string" || raw.slackMessage.trim() === "") {
   console.error(
-    "[changelog entry] Missing or empty 'entry' field. Full result:",
+    "[changelog entry] Missing or empty 'slackMessage' field. Full result:",
     JSON.stringify(raw),
   );
   process.exit(1);
@@ -24,19 +24,12 @@ if (!webhookUrl) {
   process.exit(1);
 }
 
-const toMrkdwn = (md: string) =>
-  md
-    .replace(/^#{1,6}\s+(.+)$/gm, "*$1*")
-    .replace(/\*\*(.+?)\*\*/g, "*$1*")
-    .replace(/`{3}[\w]*\n?([\s\S]*?)`{3}/g, "```$1```")
-    .replace(/`([^`]+)`/g, "`$1`");
-
 const response = await fetch(webhookUrl, {
   method: "POST",
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify({
     date: process.env.CHANGELOG_DATE ?? "",
-    message: toMrkdwn(raw.entry),
+    message: raw.slackMessage.trim(),
   }),
 });
 


### PR DESCRIPTION
Updates the daily changelog flow so AI produces a separate plaintext Slack message instead of transforming the markdown changelog entry before posting.

Validation:
- bun lint
- bun run build
