### PR TITLE
Fix broken tables in documentation pages

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,6 @@
 Adam Grzybowski <adamgrzybowski@users.noreply.github.com>
 Adrianna Cetnar <lys1k@users.noreply.github.com> <100601969+lys1k@users.noreply.github.com>
+Damián Piñones <dpinones@users.noreply.github.com>
 github-actions[bot] <github-actions[bot]@users.noreply.github.com> <41898282+github-actions[bot]@users.noreply.github.com>
 Jakub Kosmydel <kosmydel@users.noreply.github.com>
 Jan Nowakowski <jnowakow@users.noreply.github.com> <56261019+jnowakow@users.noreply.github.com>

--- a/src/content/docs/becoming-productive/harness-engineering.mdx
+++ b/src/content/docs/becoming-productive/harness-engineering.mdx
@@ -27,22 +27,65 @@ project-specific guidance belongs.
 Let's start by citing rules from <ExternalLink href="https://code.claude.com/docs/en/best-practices#write-an-effective-claude-md">Claude docs</ExternalLink>.
 They are pretty good:
 
-| ✅ Include                                            | ❌ Exclude                                          |
-|:-----------------------------------------------------|:---------------------------------------------------|
-| Bash commands Claude can't guess                     | Anything Claude can figure out by reading code     |
-| Code style rules that differ from defaults           | Standard language conventions Claude already knows |
-| Testing instructions and preferred test runners      | Detailed API documentation (link to docs instead)  |
-| Repository etiquette (branch naming, PR conventions) | Information that changes frequently                |
-| Architectural decisions specific to your project     | Long explanations or tutorials                     |
-| Developer environment quirks (required env vars)     | File-by-file descriptions of the codebase          |
-| Common gotchas or non-obvious behaviors              | Self-evident practices like “write clean code”     |
+<table>
+  <thead>
+    <tr>
+      <th>✅ Include</th>
+      <th>❌ Exclude</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Bash commands Claude can't guess</td>
+      <td>Anything Claude can figure out by reading code</td>
+    </tr>
+    <tr>
+      <td>Code style rules that differ from defaults</td>
+      <td>Standard language conventions Claude already knows</td>
+    </tr>
+    <tr>
+      <td>Testing instructions and preferred test runners</td>
+      <td>Detailed API documentation (link to docs instead)</td>
+    </tr>
+    <tr>
+      <td>Repository etiquette (branch naming, PR conventions)</td>
+      <td>Information that changes frequently</td>
+    </tr>
+    <tr>
+      <td>Architectural decisions specific to your project</td>
+      <td>Long explanations or tutorials</td>
+    </tr>
+    <tr>
+      <td>Developer environment quirks (required env vars)</td>
+      <td>File-by-file descriptions of the codebase</td>
+    </tr>
+    <tr>
+      <td>Common gotchas or non-obvious behaviors</td>
+      <td>Self-evident practices like "write clean code"</td>
+    </tr>
+  </tbody>
+</table>
 
 On top of that, we would add the following:
 
-| ✅ Include                                | ❌ Exclude                                    |
-|:-----------------------------------------|:---------------------------------------------|
-| Only crucial and frequently needed hints | Anything that is one `ls` or `cat` call away |
-| Terser language throughout the file      | Rules better handled by hooks or extensions  |
+<table>
+  <thead>
+    <tr>
+      <th>✅ Include</th>
+      <th>❌ Exclude</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Only crucial and frequently needed hints</td>
+      <td>Anything that is one <code>ls</code> or <code>cat</code> call away</td>
+    </tr>
+    <tr>
+      <td>Terser language throughout the file</td>
+      <td>Rules better handled by hooks or extensions</td>
+    </tr>
+  </tbody>
+</table>
 
 As your codebase and AGENTS.md grow, it will make sense to move chunks of that file into either skills or separate files in the `docs/` directory, while AGENTS.md becomes mostly a table of contents.
 

--- a/src/content/docs/expanding-horizons/model-pricing.mdx
+++ b/src/content/docs/expanding-horizons/model-pricing.mdx
@@ -56,10 +56,24 @@ Common subscription options:
 Token counts vary significantly by language.
 Polish, for example, requires roughly 40% more tokens than English for equivalent content — you can verify this yourself with <ExternalLink href="https://tiktokenizer.vercel.app/"/>.
 
-| Text | Tokens |
-|------|--------|
-| *"Jestem Adam i sprawdzam, ile tokenów potrzeba do zapisania tego tekstu. Czy język polski faktycznie wymaga ich więcej niż angielski?"* | 38 |
-| *"My name is Adam, and I'm checking how many tokens are needed to write this text. Does Polish actually require more tokens than English?"* | 27 |
+<table>
+  <thead>
+    <tr>
+      <th>Text</th>
+      <th>Tokens</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><em>"Jestem Adam i sprawdzam, ile tokenów potrzeba do zapisania tego tekstu. Czy język polski faktycznie wymaga ich więcej niż angielski?"</em></td>
+      <td>38</td>
+    </tr>
+    <tr>
+      <td><em>"My name is Adam, and I'm checking how many tokens are needed to write this text. Does Polish actually require more tokens than English?"</em></td>
+      <td>27</td>
+    </tr>
+  </tbody>
+</table>
 
 This is worth keeping in mind if you work in a non-English language.
 More tokens means higher cost and slower inference at scale.


### PR DESCRIPTION
## Summary
- replace the broken comparison tables in the Harness engineering page with stable HTML/MDX tables
- replace the broken token cost table in the Model pricing page with a stable HTML/MDX table
- add a `.mailmap` entry for `dpinones` so contributor attribution builds correctly

## Testing
- `bun lint` passed.
- `bun run build` passed.